### PR TITLE
chore: update dependencies and improve .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
 # Hugo 
 public/
 resources/_gen/
+
+# macOS
+.DS_Store
+**/.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/config/_default/module.toml
+++ b/config/_default/module.toml
@@ -1,2 +1,3 @@
 [[imports]]
 path = "github.com/jpanther/congo/v2"
+

--- a/content/products/daqifi/index.md
+++ b/content/products/daqifi/index.md
@@ -16,5 +16,5 @@ DAQiFi is revolutionizing the data collection experience with convenient, portab
 ## Links
 
 - [DAQiFi Website](https://daqifi.com/)
-- [{{< icon "linkedin" >}} DAQiFi LinkedIn](https://www.linkedin.com/company/daqifi/about/)
-- [{{< icon "github" >}} DAQiFi Desktop Application](https://github.com/daqifi/daqifi-desktop)
+ - [DAQiFi LinkedIn](https://www.linkedin.com/company/daqifi/about/)
+ - [DAQiFi Desktop Application](https://github.com/daqifi/daqifi-desktop)

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/tylerkron/kron.wtf
 
 go 1.16
 
-require github.com/jpanther/congo/v2 v2.9.0 // indirect
+require github.com/jpanther/congo/v2 v2.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/jpanther/congo/v2 v2.9.0 h1:mq1U8Zqw/F+9dk+AgH7W6Wl2M4LLiRP4v/BCTx4c01Y=
-github.com/jpanther/congo/v2 v2.9.0/go.mod h1:1S7DRoO1ZYS4YUdFd1LjTkdyjQwsjFWd8TqSfz3Jd+M=
+github.com/jpanther/congo/v2 v2.11.0 h1:whwuUIn20egAPfMR3HaFu7sW7/rz096bz26sgpsUAwk=
+github.com/jpanther/congo/v2 v2.11.0/go.mod h1:1S7DRoO1ZYS4YUdFd1LjTkdyjQwsjFWd8TqSfz3Jd+M=

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,3 +1,1 @@
-baseURL = 'https://example.org/'
-languageCode = 'en-us'
-title = 'My New Hugo Site'
+# Intentionally empty. Use `config/_default` for all configuration.


### PR DESCRIPTION
- Bumped `github.com/jpanther/congo/v2` from v2.9.0 to v2.11.0 in go.mod and updated go.sum accordingly.
- Enhanced .gitignore to include macOS system files and other unnecessary files.
- Cleaned up hugo.toml to clarify configuration usage.
- Minor formatting fix in module.toml.
- Updated links in DAQiFi product index for consistency.