### PR TITLE
[codex] add leadership README page

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -85,3 +85,249 @@
   opacity: 1;
   transform: none;
 }
+
+/* ── Manager README ─────────────────────────────────────────── */
+.manager-readme-hero {
+  margin: 1.5rem 0 2.75rem;
+  padding: clamp(1.25rem, 2vw, 2rem);
+  border: 1px solid rgba(14, 116, 144, 0.18);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(14, 165, 233, 0.10), rgba(20, 184, 166, 0.08) 48%, rgba(245, 158, 11, 0.08)),
+    rgba(255, 255, 255, 0.76);
+  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.08);
+}
+
+.dark .manager-readme-hero {
+  border-color: rgba(125, 211, 252, 0.18);
+  background:
+    linear-gradient(135deg, rgba(14, 165, 233, 0.16), rgba(20, 184, 166, 0.12) 48%, rgba(245, 158, 11, 0.10)),
+    rgba(15, 23, 42, 0.78);
+  box-shadow: 0 22px 58px rgba(2, 6, 23, 0.34);
+}
+
+.manager-readme-intro {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.manager-readme-kicker,
+.manager-readme-updated,
+.manager-readme-profile-label,
+.manager-readme-fact span {
+  margin: 0;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.manager-readme-kicker {
+  color: #0f766e;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.dark .manager-readme-kicker {
+  color: #5eead4;
+}
+
+.manager-readme-updated {
+  color: rgba(71, 85, 105, 0.92);
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.dark .manager-readme-updated {
+  color: rgba(226, 232, 240, 0.72);
+}
+
+.manager-readme-lede {
+  max-width: 52rem;
+  margin: 0;
+  color: inherit;
+  font-size: 1.1rem;
+  line-height: 1.75;
+}
+
+.manager-readme-profile {
+  display: grid;
+  grid-template-columns: 76px minmax(0, 1fr);
+  align-items: center;
+  gap: 1rem;
+  margin-top: 1.5rem;
+  padding-top: 1.4rem;
+  border-top: 1px solid rgba(14, 116, 144, 0.16);
+}
+
+.dark .manager-readme-profile {
+  border-top-color: rgba(125, 211, 252, 0.16);
+}
+
+.manager-readme-profile img {
+  display: block;
+  width: 76px;
+  height: 76px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid rgba(255, 255, 255, 0.88);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.18);
+}
+
+.dark .manager-readme-profile img {
+  border-color: rgba(15, 23, 42, 0.8);
+}
+
+.manager-readme-profile p {
+  margin: 0;
+}
+
+.manager-readme-profile-label {
+  margin-bottom: 0.28rem !important;
+  color: #b45309;
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.dark .manager-readme-profile-label {
+  color: #fbbf24;
+}
+
+.manager-readme-facts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem;
+  margin-top: 1.45rem;
+}
+
+.manager-readme-fact {
+  min-height: 96px;
+  padding: 1rem;
+  border: 1px solid rgba(15, 118, 110, 0.14);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.dark .manager-readme-fact {
+  border-color: rgba(94, 234, 212, 0.14);
+  background: rgba(15, 23, 42, 0.56);
+}
+
+.manager-readme-fact span {
+  display: block;
+  margin-bottom: 0.45rem;
+  color: rgba(71, 85, 105, 0.88);
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.dark .manager-readme-fact span {
+  color: rgba(226, 232, 240, 0.72);
+}
+
+.manager-readme-fact strong {
+  display: block;
+  color: inherit;
+  font-size: 1rem;
+  line-height: 1.45;
+}
+
+.manager-readme-callout {
+  margin: 1.6rem 0 2rem;
+  padding: 1rem 1.1rem;
+  border-left: 4px solid #0f766e;
+  border-radius: 0 8px 8px 0;
+  background: rgba(20, 184, 166, 0.08);
+}
+
+.dark .manager-readme-callout {
+  border-left-color: #5eead4;
+  background: rgba(45, 212, 191, 0.10);
+}
+
+.manager-readme-callout p {
+  margin: 0;
+}
+
+.manager-readme-shift-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+.manager-readme-shift-grid {
+  margin: 1.2rem 0 1.5rem;
+}
+
+.manager-readme-shift {
+  border-radius: 8px;
+  border: 1px solid rgba(14, 116, 144, 0.16);
+  background: rgba(255, 255, 255, 0.58);
+}
+
+.dark .manager-readme-shift {
+  border-color: rgba(125, 211, 252, 0.16);
+  background: rgba(15, 23, 42, 0.54);
+}
+
+.manager-readme-shift {
+  min-height: 112px;
+  padding: 1rem;
+}
+
+.manager-readme-shift span {
+  display: block;
+  letter-spacing: 0;
+}
+
+.manager-readme-shift span {
+  margin-bottom: 0.45rem;
+  color: #0f766e;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.dark .manager-readme-shift span {
+  color: #5eead4;
+}
+
+.manager-readme-shift strong {
+  display: block;
+  color: inherit;
+  font-size: 1.02rem;
+  line-height: 1.45;
+}
+
+.manager-readme-guidance-grid {
+  margin: 1.15rem 0 1.9rem;
+}
+
+.manager-readme-guidance {
+  min-height: 154px;
+}
+
+.manager-readme-guidance p {
+  margin: 0.65rem 0 0;
+  color: inherit;
+  line-height: 1.7;
+}
+
+@media (max-width: 640px) {
+  .manager-readme-profile {
+    grid-template-columns: 1fr;
+  }
+
+  .manager-readme-profile img {
+    width: 68px;
+    height: 68px;
+  }
+
+  .manager-readme-facts {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 860px) {
+  .manager-readme-shift-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/content/manager-readme/index.md
+++ b/content/manager-readme/index.md
@@ -1,0 +1,224 @@
+---
+title: "Manager README"
+description: "How Tyler Kron leads, communicates, makes decisions, and supports a product-focused engineering team."
+showAuthor: false
+showDate: false
+showPagination: false
+showReadingTime: false
+showTableOfContents: true
+sharingLinks: ["linkedin", "email"]
+---
+
+<section class="manager-readme-hero">
+  <div class="manager-readme-intro">
+    <p class="manager-readme-kicker">Tyler Kron's Manager README</p>
+    <p class="manager-readme-updated">Last updated May 2026</p>
+    <p class="manager-readme-lede">
+      This is a guide for people who report to me, and a public statement of the kind of leader I am trying to be.
+      It is a living document and a starting point, not a substitute for building trust through real work.
+    </p>
+  </div>
+
+  <div class="manager-readme-profile">
+    <img src="/img/tyler.png" alt="Tyler Kron" />
+    <div>
+      <p class="manager-readme-profile-label">Current chapter</p>
+      <p>
+        I recently moved from directing a broader Platform Engineering organization to leading a
+        product-focused team working closer to product-market fit. I want to keep the judgment that came
+        with scale without dragging scale-era habits into work that needs speed, signal, and sharper bets.
+      </p>
+    </div>
+  </div>
+
+  <div class="manager-readme-facts">
+    <div class="manager-readme-fact">
+      <span>Previous scope</span>
+      <strong>4+ teams, 3+ managers, 25+ ICs</strong>
+    </div>
+    <div class="manager-readme-fact">
+      <span>Current scope</span>
+      <strong>1 team, 4 ICs</strong>
+    </div>
+    <div class="manager-readme-fact">
+      <span>Shift in focus</span>
+      <strong>From scaling systems to finding signal</strong>
+    </div>
+    <div class="manager-readme-fact">
+      <span>Operating bias</span>
+      <strong>More evidence, less ceremony</strong>
+    </div>
+  </div>
+</section>
+
+## The short version
+
+I want the people who work for me to feel clear on what matters, trusted to think, comfortable disagreeing, and supported when the work gets murky.
+
+I care about clarity, ownership, customer evidence, simple solutions, and honest feedback. I like steady forward motion. I dislike silent drift, avoidable ambiguity, and process that no one can explain.
+
+I believe habits compound, action reduces ambiguity, and a lot of what looks like luck is really preparation, judgment, and action meeting opportunity at the right time.
+
+<aside class="manager-readme-callout">
+  <p><strong>The point of this README:</strong> make the implicit a little more explicit so we can build trust faster, avoid preventable friction, and have better conversations earlier.</p>
+</aside>
+
+## A little about me
+
+I started my career as an engineer and spent more years as an individual contributor than I have as a manager or director. That still shapes how I lead. I care about engineering judgment, clear ownership, and teams that can move without unnecessary drag.
+
+I studied Computer Engineering and Systems Engineering at Colorado State University. Go Rams!
+
+I have worked across various industries: national defense, industrial robotics, biotech, and cloud marketplaces. Much of my career has been spent in complex systems and organizations trying to scale without slowing down.
+
+Most recently, I led Platform Engineering teams focused on developer experience, golden paths, API integrations, automation, and AI-assisted development. That work taught me a lot about reducing friction across an organization.
+
+I will make mistakes. I try hard not to make the same mistake twice. I have thick skin, so if something in this README does not match your experience with me, call it out.
+
+I am a strong believer in Lean Software Development: deliver value, eliminate waste, shorten feedback loops, and keep learning. I have also written and spoken about engineering practices, including co-authoring *Microservices in Real Life: Contract Testing*, co-hosting webinars on observability, and presenting on AI and integration strategy for Managed Service Providers (MSPs).
+
+## This chapter changes some defaults
+
+For a while, my job was to help a larger platform organization scale: clearer standards, stronger enablement, more leverage across many teams.
+
+My current job is different. I am leading a smaller team working closer to product-market fit. That means I want to optimize for:
+
+<div class="manager-readme-shift-grid">
+  <div class="manager-readme-shift">
+    <span>Discipline</span>
+    <strong>Simplicity over engineering theater</strong>
+  </div>
+  <div class="manager-readme-shift">
+    <span>Signal</span>
+    <strong>Customer evidence over internal confidence</strong>
+  </div>
+  <div class="manager-readme-shift">
+    <span>Ownership</span>
+    <strong>Direct ownership over unnecessary coordination</strong>
+  </div>
+  <div class="manager-readme-shift">
+    <span>Learning</span>
+    <strong>Fast feedback loops over polished certainty</strong>
+  </div>
+</div>
+
+Some of my old instincts are still useful. Some need to relax. In Platform Engineering, it was often my job to think about the future system: standards, leverage, repeatability, and scale. In product-market fit work, the job is often to learn what is true before we harden too much around what might be true. That requires a different kind of discipline. If I am adding too much ceremony, asking for scale before we have signal, or making communication heavier than the work requires, I want you to tell me.
+
+## What you can expect from me
+
+<div class="manager-readme-shift-grid manager-readme-guidance-grid">
+  <div class="manager-readme-shift manager-readme-guidance">
+    <span>Context</span>
+    <strong>Make the why clear</strong>
+    <p>I will try to make the "why" clear: the customer problem, the business goal, the tradeoffs, and what success looks like.</p>
+  </div>
+  <div class="manager-readme-shift manager-readme-guidance">
+    <span>Presence</span>
+    <strong>Stay close without taking over</strong>
+    <p>On a small team, I will be closer to the work. I may ask deeper product, technical, or customer questions. If that ever feels like control instead of support, say so.</p>
+  </div>
+  <div class="manager-readme-shift manager-readme-guidance">
+    <span>Action</span>
+    <strong>Push toward the next useful move</strong>
+    <p>When the work is ambiguous, I will usually push us toward the next useful move: talk to a customer, test the riskiest assumption, write down the tradeoff, ship a smaller slice, or make a decision we can learn from.</p>
+  </div>
+  <div class="manager-readme-shift manager-readme-guidance">
+    <span>Quality</span>
+    <strong>Match the bar to the moment</strong>
+    <p>I care about reliability and craft, but I do not want us overbuilding before the problem has earned it.</p>
+  </div>
+  <div class="manager-readme-shift manager-readme-guidance">
+    <span>Support</span>
+    <strong>Remove friction and protect focus</strong>
+    <p>I will make decisions visible, clear friction where I can, and create air cover when the team needs focus.</p>
+  </div>
+  <div class="manager-readme-shift manager-readme-guidance">
+    <span>Feedback</span>
+    <strong>Be clear and useful</strong>
+    <p>I will give it clearly and with good intent, and I want the same in return.</p>
+  </div>
+  <div class="manager-readme-shift manager-readme-guidance">
+    <span>Pace</span>
+    <strong>Respect finite time</strong>
+    <p>More hours should not be the default answer. If everything is important, nothing is. If the work does not fit, we should cut scope, clarify priorities, or make tradeoffs visible.</p>
+  </div>
+  <div class="manager-readme-shift manager-readme-guidance">
+    <span>Transparency</span>
+    <strong>Say what I know and what I do not</strong>
+    <p>When I know something, I will share it. When I do not, I will say that too.</p>
+  </div>
+</div>
+
+## What I expect from you
+
+<div class="manager-readme-shift-grid manager-readme-guidance-grid">
+  <div class="manager-readme-shift manager-readme-guidance">
+    <span>Signal</span>
+    <strong>Surface ambiguity early</strong>
+    <p>If something is unclear, blocked, larger than expected, or pointed in the wrong direction, raise it early. Bad news does not improve with age.</p>
+  </div>
+  <div class="manager-readme-shift manager-readme-guidance">
+    <span>Judgment</span>
+    <strong>Bring a point of view</strong>
+    <p>When possible, bring the problem, the options you see, your recommendation, and what still makes you uncertain.</p>
+  </div>
+  <div class="manager-readme-shift manager-readme-guidance">
+    <span>Growth</span>
+    <strong>Keep getting better</strong>
+    <p>Take pride in your work, ask for feedback, and keep getting better at your craft.</p>
+  </div>
+  <div class="manager-readme-shift manager-readme-guidance">
+    <span>Simplicity</span>
+    <strong>Prefer simple</strong>
+    <p>I value solutions that are understandable, observable, and appropriate for the stage of the product.</p>
+  </div>
+  <div class="manager-readme-shift manager-readme-guidance">
+    <span>Customer</span>
+    <strong>Stay close to real signal</strong>
+    <p>Product-market fit comes from evidence, not internal conviction. We should be honest when the signal disagrees with us.</p>
+  </div>
+  <div class="manager-readme-shift manager-readme-guidance">
+    <span>Momentum</span>
+    <strong>Create surface area for luck</strong>
+    <p>Preparation matters. Attitude matters. Opportunity matters. Action is what turns those things into outcomes.</p>
+  </div>
+</div>
+
+## How I work with direct reports
+
+### Communication
+
+I prefer clear, high-signal communication. Async is usually best for status, context, and simple decisions. Meetings are a tool, not my default. Live conversation is better for ambiguity, conflict, product tradeoffs, customer learning, or anything where 15 minutes together prevents two days of drift.
+
+I also value simple, direct language. If we cannot explain the problem clearly, we probably do not understand it well enough yet.
+
+### Decisions
+
+I do not want us waiting for perfect information. For small, reversible decisions, I prefer speed. For larger decisions, I like lightweight written thinking: what problem are we solving, what options did we consider, what tradeoff are we choosing, and what evidence would make us revisit it?
+
+### 1:1s
+
+1:1s are for you first. They are not status meetings. I want them to be useful for coaching, context, feedback, career growth, decision support, and places where you feel stuck.
+
+### Feedback
+
+I prefer feedback that is specific, timely, direct, and useful. I try to give it that way, and I appreciate receiving it that way too.
+
+The best feedback cultures have safety, effort, and benefit: people feel safe giving and receiving feedback, they practice it often enough that it becomes normal, and the feedback helps the work or the relationship improve.
+
+
+## Things I need to watch in myself
+
+I have a strong bias toward systems thinking. That is useful until it is not.
+
+I can sometimes see patterns, abstractions, and future scaling problems earlier than they need to be solved. In Platform Engineering, that instinct was often an asset. In product-market fit work, it can become a liability if it pulls us away from learning quickly.
+
+I care a lot about the work. That is usually good. It also means I need to make sure intensity does not get confused with urgency on everything.
+
+## Closing
+
+This README is not meant to make working with me formulaic. It is meant to make it easier.
+
+People are complex. Teams are dynamic. Context changes. I reserve the right to grow.
+
+If you work with me, I hope you feel challenged, trusted, supported, and clear on what we are trying to accomplish together.

--- a/content/thought-leadership/index.md
+++ b/content/thought-leadership/index.md
@@ -37,6 +37,7 @@ Below are various engagements I've been involved with in the industry.
 
 ## Posts
 
+- May 2026: [Manager README](/manager-readme/)
 - May 2025: [Get the most out of AI](https://www.linkedin.com/posts/tylerkron_%F0%9D%97%94%F0%9D%97%9C-%F0%9D%97%B6%F0%9D%98%80-%F0%9D%97%B2%F0%9D%98%83%F0%9D%97%B2%F0%9D%97%BF%F0%9D%98%86%F0%9D%98%84%F0%9D%97%B5%F0%9D%97%B2%F0%9D%97%BF%F0%9D%97%B2-%F0%9D%97%AF%F0%9D%98%82%F0%9D%98%81-%F0%9D%97%AE-activity-7325897270757863426-idWq?utm_source=share&utm_medium=member_desktop&rcm=ACoAAAK0cIYBEAPti3QKdYollV5UE4TID4pVP8c) 
 - November 2023: [Manager README](https://www.linkedin.com/posts/tylerkron_tylerreadme-for-people-leaders-activity-7130241444375613440-azjf)
 - April 2023: [My Approach to Solving Problems](https://www.linkedin.com/posts/tylerkron_software-engineers-activity-7059554531566645248-AMBj/)


### PR DESCRIPTION
## Summary
- add a new public Leadership README page tailored to Tyler's current product-focused team chapter
- create bespoke page styling for the hero, transition tiles, and expectations sections
- link the new page from Thought Leadership so it is discoverable on-site

## Why
The existing leadership README lived outside the personal site and no longer reflected the current leadership context. This brings it onto the site with updated content and a polished presentation that better fits the rest of the portfolio.

## Impact
Visitors can now read an up-to-date leadership README directly on the site, with clearer structure around current scope, operating principles, and expectations for direct reports.

## Validation
- `hugo`
- manual browser review of the local preview at `/leadership-readme/`
- fresh local route check: `/leadership-readme/` returns 200 and `/manager-readme/` returns 404
