### PR TITLE
[codex] rename README page to leadership

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -86,7 +86,7 @@
   transform: none;
 }
 
-/* ── Manager README ─────────────────────────────────────────── */
+/* ── Leadership README ──────────────────────────────────────── */
 .manager-readme-hero {
   margin: 1.5rem 0 2.75rem;
   padding: clamp(1.25rem, 2vw, 2rem);

--- a/content/leadership-readme/index.md
+++ b/content/leadership-readme/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Manager README"
+title: "Leadership README"
 description: "How Tyler Kron leads, communicates, makes decisions, and supports a product-focused engineering team."
 showAuthor: false
 showDate: false
@@ -11,7 +11,7 @@ sharingLinks: ["linkedin", "email"]
 
 <section class="manager-readme-hero">
   <div class="manager-readme-intro">
-    <p class="manager-readme-kicker">Tyler Kron's Manager README</p>
+    <p class="manager-readme-kicker">Tyler Kron's Leadership README</p>
     <p class="manager-readme-updated">Last updated May 2026</p>
     <p class="manager-readme-lede">
       This is a guide for people who report to me, and a public statement of the kind of leader I am trying to be.

--- a/content/thought-leadership/index.md
+++ b/content/thought-leadership/index.md
@@ -37,7 +37,7 @@ Below are various engagements I've been involved with in the industry.
 
 ## Posts
 
-- May 2026: [Manager README](/manager-readme/)
+- May 2026: [Leadership README](/leadership-readme/)
 - May 2025: [Get the most out of AI](https://www.linkedin.com/posts/tylerkron_%F0%9D%97%94%F0%9D%97%9C-%F0%9D%97%B6%F0%9D%98%80-%F0%9D%97%B2%F0%9D%98%83%F0%9D%97%B2%F0%9D%97%BF%F0%9D%98%86%F0%9D%98%84%F0%9D%97%B5%F0%9D%97%B2%F0%9D%97%BF%F0%9D%97%B2-%F0%9D%97%AF%F0%9D%98%82%F0%9D%98%81-%F0%9D%97%AE-activity-7325897270757863426-idWq?utm_source=share&utm_medium=member_desktop&rcm=ACoAAAK0cIYBEAPti3QKdYollV5UE4TID4pVP8c) 
 - November 2023: [Manager README](https://www.linkedin.com/posts/tylerkron_tylerreadme-for-people-leaders-activity-7130241444375613440-azjf)
 - April 2023: [My Approach to Solving Problems](https://www.linkedin.com/posts/tylerkron_software-engineers-activity-7059554531566645248-AMBj/)


### PR DESCRIPTION
## Summary
- rename the public README page from Manager README to Leadership README
- move the route from `/manager-readme/` to `/leadership-readme/`
- update the Thought Leadership link and section comment to match

## Why
The page is about leadership style and expectations, and Tyler is still operating at director level. `Leadership README` is a better public label than `Manager README` for that context.

## Validation
- `hugo`
- local route check: `/leadership-readme/` returns 200
- local route check: `/manager-readme/` returns 404
